### PR TITLE
End rpctypedrift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ dependencies = [
  "clap",
  "floresta-rpc",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -1102,6 +1103,7 @@ dependencies = [
 name = "floresta-rpc"
 version = "0.4.0"
 dependencies = [
+ "async-trait",
  "bitcoin",
  "clap",
  "corepc-types",
@@ -1110,6 +1112,7 @@ dependencies = [
  "rcgen",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ readme = "README.md"
 # For exact versions when needed, use "=1.9.1"
 [workspace.dependencies]
 axum = "0.8"
+async-trait = "0.1"
 bitcoin = { version = "0.32", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 corepc-types = "0.11"

--- a/bin/floresta-cli/Cargo.toml
+++ b/bin/floresta-cli/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0"
 bitcoin = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 
 # Local dependencies
 floresta-rpc = { workspace = true, features = ["clap"] }

--- a/crates/floresta-rpc/Cargo.toml
+++ b/crates/floresta-rpc/Cargo.toml
@@ -15,12 +15,14 @@ keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
 categories = ["cryptography::cryptocurrencies", "command-line-utilities"]
 
 [dependencies]
+async-trait = { workspace = true }
 bitcoin = { workspace = true }
 clap = { workspace = true, optional = true }
 corepc-types = { workspace = true }
 jsonrpc = { version = "0.18", features = ["minreq_http"], optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/floresta-rpc/src/jsonrpc_client.rs
+++ b/crates/floresta-rpc/src/jsonrpc_client.rs
@@ -1,9 +1,30 @@
 use std::fmt::Debug;
 
+use async_trait::async_trait;
+use bitcoin::BlockHash;
+use bitcoin::Txid;
+use corepc_types::v29::GetTxOut;
+use corepc_types::v30::GetBestBlockHash;
+use corepc_types::v30::GetBlockCount;
+use corepc_types::v30::GetBlockHash;
+use corepc_types::v30::GetBlockHeader;
+use corepc_types::v30::GetRpcInfo;
+use corepc_types::v30::GetTransaction;
+use corepc_types::v30::RescanBlockchain;
+use corepc_types::v30::SendRawTransaction;
 use serde::Deserialize;
+use serde_json::Number;
+use serde_json::Value;
 
-use crate::rpc::JsonRPCClient;
-
+use crate::rpc::FlorestaJsonRPC;
+use crate::rpc::RpcResult;
+use crate::rpc_types::AddNodeCommand;
+use crate::rpc_types::Error;
+use crate::rpc_types::GetBlock;
+use crate::rpc_types::GetBlockchainInfoRes;
+use crate::rpc_types::GetMemInfoRes;
+use crate::rpc_types::PeerInfo;
+use crate::rpc_types::RescanConfidence;
 // Define a Client struct that wraps a jsonrpc::Client
 #[derive(Debug)]
 pub struct Client(jsonrpc::Client);
@@ -32,37 +53,200 @@ impl Client {
     }
 
     // Method to make an RPC call
-    pub fn rpc_call<Response>(
+    pub fn rpc_call<T: for<'a> serde::de::Deserialize<'a>>(
         &self,
         method: &str,
         params: &[serde_json::Value],
-    ) -> Result<Response, crate::rpc_types::Error>
-    where
-        Response: for<'a> serde::de::Deserialize<'a> + Debug,
-    {
-        // Serialize parameters to raw JSON value
+    ) -> RpcResult<T> {
         let raw = serde_json::value::to_raw_value(params)?;
-        // Build the RPC request
-        let req = self.0.build_request(method, Some(&*raw));
-        // Send the request and handle the response
-        let resp = self
-            .0
-            .send_request(req)
-            .map_err(crate::rpc_types::Error::from);
 
-        // Deserialize and return the result
-        Ok(resp?.result()?)
+        let req = self.0.build_request(method, Some(&*raw));
+
+        self.0
+            .send_request(req)
+            .map_err(crate::rpc_types::Error::from)?
+            .result()
+            .map_err(crate::rpc_types::Error::from)
     }
 }
 
-// Implement the JsonRPCClient trait for Client
-impl JsonRPCClient for Client {
-    fn call<T: for<'a> serde::de::Deserialize<'a> + Debug>(
+#[async_trait]
+impl FlorestaJsonRPC for Client {
+    async fn find_tx_out(
         &self,
-        method: &str,
-        params: &[serde_json::Value],
-    ) -> Result<T, crate::rpc_types::Error> {
-        self.rpc_call(method, params)
+        tx_id: Txid,
+        outpoint: u32,
+        script: String,
+        height_hint: u32,
+    ) -> RpcResult<Value> {
+        self.rpc_call(
+            "findtxout",
+            &[
+                Value::String(tx_id.to_string()),
+                Value::Number(Number::from(outpoint)),
+                Value::String(script),
+                Value::Number(Number::from(height_hint)),
+            ],
+        )
+    }
+
+    async fn uptime(&self) -> RpcResult<u32> {
+        self.rpc_call("uptime", &[])
+    }
+
+    async fn get_memory_info(&self, mode: String) -> RpcResult<GetMemInfoRes> {
+        self.rpc_call("getmemoryinfo", &[Value::String(mode)])
+    }
+
+    async fn get_rpc_info(&self) -> RpcResult<GetRpcInfo> {
+        self.rpc_call("getrpcinfo", &[])
+    }
+
+    async fn add_node(
+        &self,
+        node: String,
+        command: AddNodeCommand,
+        v2transport: bool,
+    ) -> RpcResult<Value> {
+        self.rpc_call(
+            "addnode",
+            &[
+                Value::String(node),
+                Value::String(command.to_string()),
+                Value::Bool(v2transport),
+            ],
+        )
+    }
+
+    async fn stop(&self) -> RpcResult<String> {
+        self.rpc_call("stop", &[])
+    }
+
+    async fn rescanblockchain(
+        &self,
+        start_height: Option<u32>,
+        stop_height: Option<u32>,
+        use_timestamp: bool,
+        confidence: RescanConfidence,
+    ) -> RpcResult<RescanBlockchain> {
+        let start_height = start_height.unwrap_or(0u32);
+
+        let stop_height = stop_height.unwrap_or(0u32);
+
+        self.rpc_call(
+            "rescanblockchain",
+            &[
+                Value::Number(Number::from(start_height)),
+                Value::Number(Number::from(stop_height)),
+                Value::Bool(use_timestamp),
+                serde_json::to_value(&confidence).expect("RescanConfidence implements Ser/De"),
+            ],
+        )
+    }
+
+    async fn get_roots(&self) -> RpcResult<Vec<String>> {
+        self.rpc_call("getroots", &[])
+    }
+
+    async fn get_block(&self, hash: BlockHash, verbosity: Option<u32>) -> RpcResult<GetBlock> {
+        let verbosity = verbosity.unwrap_or(0);
+        self.rpc_call(
+            "getblock",
+            &[
+                Value::String(hash.to_string()),
+                Value::Number(Number::from(verbosity)),
+            ],
+        )
+    }
+
+    async fn get_block_count(&self) -> RpcResult<GetBlockCount> {
+        self.rpc_call("getblockcount", &[])
+    }
+
+    async fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> RpcResult<GetTxOut> {
+        let result: serde_json::Value = self.rpc_call(
+            "gettxout",
+            &[
+                Value::String(tx_id.to_string()),
+                Value::Number(Number::from(outpoint)),
+            ],
+        )?;
+        if result.is_null() {
+            return Err(Error::TxOutNotFound);
+        }
+        serde_json::from_value(result).map_err(Error::Serde)
+    }
+
+    async fn get_txout_proof(
+        &self,
+        txids: Vec<Txid>,
+        blockhash: Option<BlockHash>,
+    ) -> RpcResult<Option<String>> {
+        let params: Vec<Value> = match blockhash {
+            Some(blockhash) => vec![
+                serde_json::to_value(txids)
+                    .expect("Unreachable, Vec<Txid> can be parsed into a json value"),
+                Value::String(blockhash.to_string()),
+            ],
+            None => {
+                let txids = serde_json::to_value(txids)
+                    .expect("Unreachable, Vec<Txid> can be parsed into a json value");
+                vec![txids]
+            }
+        };
+        self.rpc_call("gettxoutproof", &params)
+    }
+
+    async fn get_peer_info(&self) -> RpcResult<Vec<PeerInfo>> {
+        self.rpc_call("getpeerinfo", &[])
+    }
+
+    async fn get_best_block_hash(&self) -> RpcResult<GetBestBlockHash> {
+        self.rpc_call("getbestblockhash", &[])
+    }
+
+    async fn get_block_hash(&self, height: u32) -> RpcResult<GetBlockHash> {
+        self.rpc_call("getblockhash", &[Value::Number(Number::from(height))])
+    }
+
+    async fn get_transaction(
+        &self,
+        tx_id: Txid,
+        verbosity: Option<bool>,
+    ) -> RpcResult<GetTransaction> {
+        let verbosity = verbosity.unwrap_or(false);
+        self.rpc_call(
+            "gettransaction",
+            &[Value::String(tx_id.to_string()), Value::Bool(verbosity)],
+        )
+    }
+
+    async fn load_descriptor(&self, descriptor: String) -> RpcResult<bool> {
+        self.rpc_call("loaddescriptor", &[Value::String(descriptor)])
+    }
+
+    async fn get_block_filter(&self, height: u32) -> RpcResult<String> {
+        self.rpc_call("getblockfilter", &[Value::Number(Number::from(height))])
+    }
+
+    async fn get_block_header(&self, hash: BlockHash) -> RpcResult<GetBlockHeader> {
+        self.rpc_call("getblockheader", &[Value::String(hash.to_string())])
+    }
+
+    async fn get_blockchain_info(&self) -> RpcResult<GetBlockchainInfoRes> {
+        self.rpc_call("getblockchaininfo", &[])
+    }
+
+    async fn send_raw_transaction(&self, tx: String) -> RpcResult<SendRawTransaction> {
+        self.rpc_call("sendrawtransaction", &[Value::String(tx)])
+    }
+
+    async fn list_descriptors(&self) -> RpcResult<Vec<String>> {
+        self.rpc_call("listdescriptors", &[])
+    }
+
+    async fn ping(&self) -> RpcResult<()> {
+        self.rpc_call("ping", &[])
     }
 }
 

--- a/crates/floresta-rpc/src/rpc.rs
+++ b/crates/floresta-rpc/src/rpc.rs
@@ -1,57 +1,113 @@
-use std::fmt::Debug;
-
-use bitcoin::block::Header as BlockHeader;
+use async_trait::async_trait;
 use bitcoin::BlockHash;
 use bitcoin::Txid;
 use corepc_types::v29::GetTxOut;
-use serde_json::Number;
+use corepc_types::v30::GetBestBlockHash;
+use corepc_types::v30::GetBlockCount;
+use corepc_types::v30::GetBlockHash;
+use corepc_types::v30::GetBlockHeader;
+use corepc_types::v30::GetRpcInfo;
+use corepc_types::v30::GetTransaction;
+use corepc_types::v30::RescanBlockchain;
+use corepc_types::v30::SendRawTransaction;
 use serde_json::Value;
 
-use crate::rpc_types;
-use crate::rpc_types::*;
+use crate::rpc_types::AddNodeCommand;
+use crate::rpc_types::Error;
+use crate::rpc_types::GetBlock;
+use crate::rpc_types::GetBlockchainInfoRes;
+use crate::rpc_types::GetMemInfoRes;
+use crate::rpc_types::PeerInfo;
+use crate::rpc_types::RescanConfidence;
 
-type Result<T> = std::result::Result<T, rpc_types::Error>;
+pub type RpcResult<T> = std::result::Result<T, Error>;
 
-/// A trait specifying all possible methods for floresta's json-rpc
-pub trait FlorestaRPC {
+/// A trait defining the signature of our rpc commands.
+///
+/// Both client and server should implement this to ensure type compatibility between them.
+///
+/// The client would implement this building a request for the server with the given input,
+/// and the server by receiving the request have to decode the request calling the exact same
+/// method on its side, returning the data and the request after that, which should be received
+/// by the client returning the received data.
+///
+/// Is it confuse? With that we can do type inferring on both sides without any worry of them
+/// mismatching.
+///
+/// To maintain API compatibility for all sides the signature of the commands **need** to
+/// be the same, with this trait the only part that can differ is CLI <- -> Client.
+///
+/// I know thats ugly but it should help a lot finding references in the code just by keeping
+/// the method name the same as the command.
+#[async_trait]
+pub trait FlorestaJsonRPC {
     /// Get the BIP158 filter for a given block height
     ///
     /// BIP158 filters are a compact representation of the set of transactions in a block,
     /// designed for efficient light client synchronization. This method returns the filter
     /// for a given block height, encoded as a hexadecimal string.
     /// You need to have enabled block filters by setting the `blockfilters=1` option
-    fn get_block_filter(&self, height: u32) -> Result<String>;
+    async fn get_block_filter(&self, _height: u32) -> RpcResult<String> {
+        Err(Error::NotImplemented)
+    }
+
     /// Returns general information about the chain we are on
     ///
     /// This method returns a bunch of information about the chain we are on, including
     /// the current height, the best block hash, the difficulty, and whether we are
     /// currently in IBD (Initial Block Download) mode.
-    fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes>;
+    async fn get_blockchain_info(&self) -> RpcResult<GetBlockchainInfoRes> {
+        Err(Error::NotImplemented)
+    }
+
     /// Returns the hash of the best (tip) block in the most-work fully-validated chain.
-    fn get_best_block_hash(&self) -> Result<BlockHash>;
+    async fn get_best_block_hash(&self) -> RpcResult<GetBestBlockHash> {
+        Err(Error::NotImplemented)
+    }
+
     /// Returns the hash of the block at the given height
     ///
     /// This method returns the hash of the block at the given height. If the height is
     /// invalid, an error is returned.
-    fn get_block_hash(&self, height: u32) -> Result<BlockHash>;
+    async fn get_block_hash(&self, _height: u32) -> RpcResult<GetBlockHash> {
+        Err(Error::NotImplemented)
+    }
+
     /// Returns the block header for the given block hash
     ///
     /// This method returns the block header for the given block hash, as defined
     /// in the Bitcoin protocol specification. A header contains the block's version,
     /// the previous block hash, the merkle root, the timestamp, the difficulty target,
     /// and the nonce.
-    fn get_block_header(&self, hash: BlockHash) -> Result<BlockHeader>;
+    async fn get_block_header(&self, _hash: BlockHash) -> RpcResult<GetBlockHeader> {
+        Err(Error::NotImplemented)
+    }
+
     /// Gets a transaction from the blockchain
     ///
     /// This method returns a transaction that's cached in our wallet. If the verbosity flag is
     /// set to false, the transaction is returned as a hexadecimal string. If the verbosity
     /// flag is set to true, the transaction is returned as a json object.
-    fn get_transaction(&self, tx_id: Txid, verbosity: Option<bool>) -> Result<Value>;
+    async fn get_transaction(
+        &self,
+        _tx_id: Txid,
+        _verbosity: Option<bool>,
+    ) -> RpcResult<GetTransaction> {
+        Err(Error::NotImplemented)
+    }
+
     /// Returns the proof that one or more transactions were included in a block
     ///
     /// This method returns the Merkle proof, showing that a transaction was included in a block.
     /// The pooof is returned as a vector hexadecimal string.
-    fn get_txout_proof(&self, txids: Vec<Txid>, blockhash: Option<BlockHash>) -> Option<String>;
+    async fn get_txout_proof(
+        &self,
+        _txids: Vec<Txid>,
+        _blockhash: Option<BlockHash>,
+    ) -> RpcResult<Option<String>> {
+        Err(Error::NotImplemented)
+    }
+
     /// Loads up a descriptor into the wallet
     ///
     /// This method loads up a descriptor into the wallet. If the rescan option is not None,
@@ -59,279 +115,132 @@ pub trait FlorestaRPC {
     /// compact block filters enabled, this process will be much faster and use less bandwidth.
     /// The rescan parameter is the height at which to start the rescan, and should be at least
     /// as old as the oldest transaction this descriptor could have been used in.
-    fn load_descriptor(&self, descriptor: String) -> Result<bool>;
+    async fn load_descriptor(&self, _descriptor: String) -> RpcResult<bool> {
+        Err(Error::NotImplemented)
+    }
 
     #[doc = include_str!("../../../doc/rpc/rescanblockchain.md")]
-    fn rescanblockchain(
+    async fn rescanblockchain(
         &self,
-        start_block: Option<u32>,
-        stop_block: Option<u32>,
-        use_timestamp: bool,
-        confidence: RescanConfidence,
-    ) -> Result<bool>;
+        _start_block: Option<u32>,
+        _stop_block: Option<u32>,
+        _use_timestamp: bool,
+        _confidence: RescanConfidence,
+    ) -> RpcResult<RescanBlockchain> {
+        Err(Error::NotImplemented)
+    }
 
     /// Returns the current height of the blockchain
-    fn get_block_count(&self) -> Result<u32>;
+    async fn get_block_count(&self) -> RpcResult<GetBlockCount> {
+        Err(Error::NotImplemented)
+    }
+
     /// Sends a hex-encoded transaction to the network
     ///
     /// This method sends a transaction to the network. The transaction should be encoded as a
     /// hexadecimal string. If the transaction is valid, it will be broadcast to the network, and
     /// return the transaction id. If the transaction is invalid, an error will be returned.
-    fn send_raw_transaction(&self, tx: String) -> Result<Txid>;
+    async fn send_raw_transaction(&self, _tx: String) -> RpcResult<SendRawTransaction> {
+        Err(Error::NotImplemented)
+    }
+
     /// Gets the current accumulator for the chain we're on
     ///
     /// This method returns the current accumulator for the chain we're on. The accumulator is
     /// a set of roots, that let's us prove that a UTXO exists in the chain. This method returns
     /// a vector of hexadecimal strings, each of which is a root in the accumulator.
-    fn get_roots(&self) -> Result<Vec<String>>;
+    async fn get_roots(&self) -> RpcResult<Vec<String>> {
+        Err(Error::NotImplemented)
+    }
+
     /// Gets information about the peers we're connected with
     ///
     /// This method returns information about the peers we're connected with. This includes
     /// the peer's IP address, the peer's version, the peer's user agent, the transport protocol
     /// and the peer's current height.
-    fn get_peer_info(&self) -> Result<Vec<PeerInfo>>;
+    async fn get_peer_info(&self) -> RpcResult<Vec<PeerInfo>> {
+        Err(Error::NotImplemented)
+    }
+
     /// Returns a block, given a block hash
     ///
     /// This method returns a block, given a block hash. If the verbosity flag is 0, the block
     /// is returned as a hexadecimal string. If the verbosity flag is 1, the block is returned
     /// as a json object.
-    fn get_block(&self, hash: BlockHash, verbosity: Option<u32>) -> Result<GetBlockRes>;
+    async fn get_block(&self, _hash: BlockHash, _verbosity: Option<u32>) -> RpcResult<GetBlock> {
+        Err(Error::NotImplemented)
+    }
+
     /// Return a cached transaction output
     ///
     /// This method returns a cached transaction output. If the output is not in the cache,
     /// or is spent, an empty object is returned. If you want to find a utxo that's not in
     /// the cache, you can use the findtxout method.
-    fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<GetTxOut>;
+    async fn get_tx_out(&self, _tx_id: Txid, _outpoint: u32) -> RpcResult<GetTxOut> {
+        Err(Error::NotImplemented)
+    }
+
     /// Stops the florestad process
     ///
     /// This can be used to gracefully stop the florestad process.
-    fn stop(&self) -> Result<String>;
+    async fn stop(&self) -> RpcResult<String> {
+        Err(Error::NotImplemented)
+    }
+
     /// Tells florestad to connect with a peer
     ///
     /// You can use this to connect with a given node, providing it's IP address and port.
     /// If the `v2transport` option is set, we won't retry connecting using the old, unencrypted
     /// P2P protocol.
     #[doc = include_str!("../../../doc/rpc/addnode.md")]
-    fn add_node(&self, node: String, command: AddNodeCommand, v2transport: bool) -> Result<Value>;
+    async fn add_node(
+        &self,
+        _node: String,
+        _command: AddNodeCommand,
+        _v2transport: bool,
+    ) -> RpcResult<Value> {
+        Err(Error::NotImplemented)
+    }
+
     /// Finds an specific utxo in the chain
     ///
     /// You can use this to look for a utxo. If it exists, it will return the amount and
     /// scriptPubKey of this utxo. It returns an empty object if the utxo doesn't exist.
     /// You must have enabled block filters by setting the `blockfilters=1` option.
-    fn find_tx_out(
+    async fn find_tx_out(
         &self,
-        tx_id: Txid,
-        outpoint: u32,
-        script: String,
-        height_hint: u32,
-    ) -> Result<Value>;
+        _tx_id: Txid,
+        _outpoint: u32,
+        _script: String,
+        _height_hint: u32,
+    ) -> RpcResult<Value> {
+        Err(Error::NotImplemented)
+    }
+
     /// Returns statistics about Floresta's memory usage.
     ///
     /// Returns zeroed values for all runtimes that are not *-gnu or MacOS.
-    fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
+    async fn get_memory_info(&self, _mode: String) -> RpcResult<GetMemInfoRes> {
+        Err(Error::NotImplemented)
+    }
+
     /// Returns stats about our RPC server
-    fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;
+    async fn get_rpc_info(&self) -> RpcResult<GetRpcInfo> {
+        Err(Error::NotImplemented)
+    }
+
     /// Returns for how long florestad has been running, in seconds
-    fn uptime(&self) -> Result<u32>;
+    async fn uptime(&self) -> RpcResult<u32> {
+        Err(Error::NotImplemented)
+    }
+
     /// Returns a list of all descriptors currently loaded in the wallet
-    fn list_descriptors(&self) -> Result<Vec<String>>;
+    async fn list_descriptors(&self) -> RpcResult<Vec<String>> {
+        Err(Error::NotImplemented)
+    }
+
     /// Sends a ping to all peers, checking if they are still alive
-    fn ping(&self) -> Result<()>;
-}
-
-/// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
-/// that will let us call any method on the client, and then implement the methods on any
-/// client that implements this trait.
-pub trait JsonRPCClient: Sized {
-    /// Calls a method on the client
-    ///
-    /// This should call the appropriated rpc method and return a parsed response or error.
-    fn call<T>(&self, method: &str, params: &[Value]) -> Result<T>
-    where
-        T: for<'a> serde::de::Deserialize<'a> + serde::de::DeserializeOwned + Debug;
-}
-
-impl<T: JsonRPCClient> FlorestaRPC for T {
-    fn find_tx_out(
-        &self,
-        tx_id: Txid,
-        outpoint: u32,
-        script: String,
-        height_hint: u32,
-    ) -> Result<Value> {
-        self.call(
-            "findtxout",
-            &[
-                Value::String(tx_id.to_string()),
-                Value::Number(Number::from(outpoint)),
-                Value::String(script),
-                Value::Number(Number::from(height_hint)),
-            ],
-        )
-    }
-
-    fn uptime(&self) -> Result<u32> {
-        self.call("uptime", &[])
-    }
-
-    fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes> {
-        self.call("getmemoryinfo", &[Value::String(mode)])
-    }
-
-    fn get_rpc_info(&self) -> Result<GetRpcInfoRes> {
-        self.call("getrpcinfo", &[])
-    }
-
-    fn add_node(&self, node: String, command: AddNodeCommand, v2transport: bool) -> Result<Value> {
-        self.call(
-            "addnode",
-            &[
-                Value::String(node),
-                Value::String(command.to_string()),
-                Value::Bool(v2transport),
-            ],
-        )
-    }
-
-    fn stop(&self) -> Result<String> {
-        self.call("stop", &[])
-    }
-
-    fn rescanblockchain(
-        &self,
-        start_height: Option<u32>,
-        stop_height: Option<u32>,
-        use_timestamp: bool,
-        confidence: RescanConfidence,
-    ) -> Result<bool> {
-        let start_height = start_height.unwrap_or(0u32);
-
-        let stop_height = stop_height.unwrap_or(0u32);
-
-        self.call(
-            "rescanblockchain",
-            &[
-                Value::Number(Number::from(start_height)),
-                Value::Number(Number::from(stop_height)),
-                Value::Bool(use_timestamp),
-                serde_json::to_value(&confidence).expect("RescanConfidence implements Ser/De"),
-            ],
-        )
-    }
-
-    fn get_roots(&self) -> Result<Vec<String>> {
-        self.call("getroots", &[])
-    }
-
-    fn get_block(&self, hash: BlockHash, verbosity: Option<u32>) -> Result<GetBlockRes> {
-        let verbosity = verbosity.unwrap_or(0);
-
-        match verbosity {
-            0 => {
-                let block = self.call(
-                    "getblock",
-                    &[
-                        Value::String(hash.to_string()),
-                        Value::Number(Number::from(verbosity)),
-                    ],
-                )?;
-                Ok(GetBlockRes::Serialized(block))
-            }
-
-            1 => {
-                let block = self.call(
-                    "getblock",
-                    &[
-                        Value::String(hash.to_string()),
-                        Value::Number(Number::from(verbosity)),
-                    ],
-                )?;
-                Ok(GetBlockRes::Verbose(block))
-            }
-
-            _ => Err(rpc_types::Error::InvalidVerbosity),
-        }
-    }
-
-    fn get_block_count(&self) -> Result<u32> {
-        self.call("getblockcount", &[])
-    }
-
-    fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<GetTxOut> {
-        let result: serde_json::Value = self.call(
-            "gettxout",
-            &[
-                Value::String(tx_id.to_string()),
-                Value::Number(Number::from(outpoint)),
-            ],
-        )?;
-        if result.is_null() {
-            return Err(Error::TxOutNotFound);
-        }
-        serde_json::from_value(result).map_err(Error::Serde)
-    }
-
-    fn get_txout_proof(&self, txids: Vec<Txid>, blockhash: Option<BlockHash>) -> Option<String> {
-        let params: Vec<Value> = match blockhash {
-            Some(blockhash) => vec![
-                serde_json::to_value(txids)
-                    .expect("Unreachable, Vec<Txid> can be parsed into a json value"),
-                Value::String(blockhash.to_string()),
-            ],
-            None => {
-                let txids = serde_json::to_value(txids)
-                    .expect("Unreachable, Vec<Txid> can be parsed into a json value");
-                vec![txids]
-            }
-        };
-        self.call("gettxoutproof", &params).ok()
-    }
-
-    fn get_peer_info(&self) -> Result<Vec<PeerInfo>> {
-        self.call("getpeerinfo", &[])
-    }
-
-    fn get_best_block_hash(&self) -> Result<BlockHash> {
-        self.call("getbestblockhash", &[])
-    }
-
-    fn get_block_hash(&self, height: u32) -> Result<BlockHash> {
-        self.call("getblockhash", &[Value::Number(Number::from(height))])
-    }
-
-    fn get_transaction(&self, tx_id: Txid, verbosity: Option<bool>) -> Result<Value> {
-        let verbosity = verbosity.unwrap_or(false);
-        self.call(
-            "gettransaction",
-            &[Value::String(tx_id.to_string()), Value::Bool(verbosity)],
-        )
-    }
-
-    fn load_descriptor(&self, descriptor: String) -> Result<bool> {
-        self.call("loaddescriptor", &[Value::String(descriptor)])
-    }
-
-    fn get_block_filter(&self, height: u32) -> Result<String> {
-        self.call("getblockfilter", &[Value::Number(Number::from(height))])
-    }
-
-    fn get_block_header(&self, hash: BlockHash) -> Result<BlockHeader> {
-        self.call("getblockheader", &[Value::String(hash.to_string())])
-    }
-
-    fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes> {
-        self.call("getblockchaininfo", &[])
-    }
-
-    fn send_raw_transaction(&self, tx: String) -> Result<Txid> {
-        self.call("sendrawtransaction", &[Value::String(tx)])
-    }
-
-    fn list_descriptors(&self) -> Result<Vec<String>> {
-        self.call("listdescriptors", &[])
-    }
-
-    fn ping(&self) -> Result<()> {
-        self.call("ping", &[])
+    async fn ping(&self) -> RpcResult<()> {
+        Err(Error::NotImplemented)
     }
 }

--- a/crates/floresta-rpc/src/rpc_types.rs
+++ b/crates/floresta-rpc/src/rpc_types.rs
@@ -1,7 +1,16 @@
 use std::fmt::Display;
 
+use corepc_types::v30::GetBlockVerboseOne;
+use corepc_types::v30::GetBlockVerboseZero;
 use serde::Deserialize;
 use serde::Serialize;
+
+#[derive(Debug, Deserialize, Serialize)]
+/// Enum holding the possibilitty to contain `GetBlockVerboseOne` or `GetBlockVerboseZero`
+pub enum GetBlock {
+    One(GetBlockVerboseOne),
+    Two(GetBlockVerboseZero),
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 /// Return type for the `gettxoutproof` rpc command, the internal is
@@ -313,7 +322,7 @@ pub enum Error {
     JsonRpc(jsonrpc::Error),
 
     /// An error internal to our jsonrpc server
-    Api(serde_json::Value),
+    Internal(String),
 
     /// The server sent an empty response
     EmptyResponse,
@@ -326,6 +335,9 @@ pub enum Error {
 
     /// The requested transaction output was not found
     TxOutNotFound,
+
+    /// Returned in every default implementation of `FlorestaJsonRpc`
+    NotImplemented,
 }
 
 impl From<serde_json::Error> for Error {
@@ -346,12 +358,13 @@ impl Display for Error {
         match self {
             #[cfg(feature = "with-jsonrpc")]
             Error::JsonRpc(e) => write!(f, "JsonRpc returned an error {e}"),
-            Error::Api(e) => write!(f, "general jsonrpc error: {e}"),
+            Error::Internal(e) => write!(f, "Internal Server error: {e}"),
             Error::Serde(e) => write!(f, "error while deserializing the response: {e}"),
             Error::EmptyResponse => write!(f, "got an empty response from server"),
             Error::InvalidVerbosity => write!(f, "invalid verbosity level"),
             Error::InvalidRescanVal => write!(f, "Invalid rescan values"),
             Error::TxOutNotFound => write!(f, "Transaction output was not found"),
+            Error::NotImplemented => write!(f, "This command is not Implemented"),
         }
     }
 }


### PR DESCRIPTION
Im trying to unify signatures between server and client making them to implement the same trait... 

Client side is implemented but tests are failing because server side doesnt implement the trait yet...

Theres a lot of boilerplate breaking this so im pushing this PR expecting for the agent to help me implement that boilerplate

Now im splitting what is server specific methods, results and errors and rpc related.